### PR TITLE
Fix: 支持带有端口号及 HTTP 协议的反代与本地部署 / Support reverse proxy deployments with custom ports and HTTP

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -1,4 +1,4 @@
-// 更新日期: 2026-06-28
+// 更新日期: 2026-07-27
 // 更新内容:
 // 1. 无论是否重定向，只要目标是 AWS S3，就自动补全 x-amz-content-sha256 和 x-amz-date
 // 2. 改进Docker镜像路径处理逻辑，支持多种格式: 如 hello-world | library/hello-world | docker.io/library/hello-world
@@ -7,6 +7,7 @@
 // 5. 支持 Git smart-http 协议代理，解决 git clone 时 GitHub 返回 dumb-http 403 错误
 // 6. 支持 GitLab 系列域名（gitlab.com 等）的 git clone 加速
 // 7. 首页新增 Git Clone 加速功能模块，方便生成加速命令
+// 8. 改进链接的拼接逻辑，兼容反向代理下的非 https 以及带有端口号的 host
 // 用户配置区域开始 =================================
 // 以下变量用于配置代理服务的白名单和安全设置，可根据需求修改。
 
@@ -276,7 +277,8 @@ const HOMEPAGE_HTML = `
 
   <script>
     // 动态获取当前域名
-    const currentDomain = window.location.hostname;
+    const currentOrigin = window.location.origin;
+    const currentHost = window.location.host;
 
     // 主题切换
     function toggleTheme() {
@@ -370,7 +372,7 @@ const HOMEPAGE_HTML = `
         githubIsGitMode = true;
         submitBtn.textContent = '获取加速命令';
         const domainPath = input.substring(8); // 去掉 https://
-        const proxyUrl = 'https://' + currentDomain + '/https://' + domainPath;
+        const proxyUrl =  currentOrigin + '/https://' + domainPath;
         githubAcceleratedUrl = 'git clone ' + proxyUrl;
         result.textContent = '加速命令: ' + githubAcceleratedUrl;
         result.classList.remove('hidden');
@@ -389,7 +391,7 @@ const HOMEPAGE_HTML = `
       githubIsGitMode = false;
       submitBtn.textContent = '获取加速链接';
       // 保持现有格式：域名/https://原始链接
-      githubAcceleratedUrl = 'https://' + currentDomain + '/https://' + input.substring(8);
+      githubAcceleratedUrl = currentOrigin + '/https://' + input.substring(8);
       result.textContent = '加速链接: ' + githubAcceleratedUrl;
       result.classList.remove('hidden');
       buttons.classList.remove('hidden');
@@ -429,7 +431,7 @@ const HOMEPAGE_HTML = `
         buttons.classList.add('hidden');
         return;
       }
-      dockerCommand = 'docker pull ' + currentDomain + '/' + input;
+      dockerCommand = 'docker pull ' + currentHost + '/' + input;
       result.textContent = '加速命令: ' + dockerCommand;
       result.classList.remove('hidden');
       buttons.classList.remove('hidden');


### PR DESCRIPTION
**问题描述**
在当前版本的前端页面中，生成加速链接时强行拼接了 `https://` 协议，并使用了 `window.location.hostname`。当用户通过非标准环境（例如本地局域网或 Nginx 反向代理配置了诸如 `[http://10.0.0.1:1082](http://10.0.0.1:1082)` 的地址）访问时，生成的命令会丢失端口号并强制使用 HTTPS。这会导致生成的代理命令无法命中用户的反代网关，出现连接拒绝或超时。

**修改内容**

1. GitHub 链接修复：采用 `window.location.origin` 替代 `https://` + `hostname`。动态继承用户当前访问的协议（HTTP/HTTPS）及端口。
2. Docker 命令修复：由于 Docker pull 不能带协议头，采用 `window.location.host` 替代 `hostname`，确保生成的 Docker 镜像拉取命令准确带上端口号。

**预期影响**
完美兼容反向代理、局域网 IP 直连、带端口的自定义域名等复杂部署场景。对于常规部署在 443 端口并使用 HTTPS 域名的老用户完全透明，无任何副作用。

**补充说明（私有部署与反代场景）**
分享一下本人的私有部署场景：因为暂时不想公开访问，故通过反向代理（如 Nginx）结合 Cloudflare Zero Trust (Access) 鉴权，nginx 向 headers 写入 service token 实现无感认证。

---

**Description**
In the current version, the frontend hardcodes the `https://` protocol and uses `window.location.hostname` when generating acceleration links. When users access the service via non-standard environments (e.g., local LAN, reverse proxy like `[http://10.0.0.1:1082](http://10.0.0.1:1082)`), the generated commands drop the custom port and force HTTPS. This causes connection refusals or timeouts because the traffic cannot hit the user's proxy gateway.

**Changes**

1. GitHub links: Replaced the hardcoded `https://` + `hostname` with `window.location.origin`. This dynamically inherits the current protocol (HTTP/HTTPS) and port.
2. Docker commands: Replaced `window.location.hostname` with `window.location.host` to ensure the generated docker pull commands accurately include the port number.

**Impact**
Perfectly compatible with complex deployment scenarios such as reverse proxies, local IPs, and custom domains with ports. Completely transparent with no side effects for existing users deployed on standard port 443 with HTTPS.
